### PR TITLE
Fix incorrect import

### DIFF
--- a/tokenmagic/module/autoTemplate/TheWitcherTRPG.js
+++ b/tokenmagic/module/autoTemplate/TheWitcherTRPG.js
@@ -15,7 +15,7 @@ export class AutoTemplateTheWitcherTRPG {
 			},
 		};
 
-		Object.keys(CONFIG.witcher.meleeSkills).forEach((meleeSkillType) => {
+		Object.keys(CONFIG.WITCHER.meleeSkills).forEach((meleeSkillType) => {
 			if (defaultConfig.categories[meleeSkillType] == undefined) {
 				const config = { opacity: defaultOpacity, tint: null };
 				switch (meleeSkillType.toLowerCase()) {
@@ -84,7 +84,7 @@ export class AutoTemplateTheWitcherTRPG {
 	getData() {
 		return {
 			hasAutoTemplates: true,
-			meleeSkills: CONFIG.witcher.meleeSkills,
+			meleeSkills: CONFIG.WITCHER.meleeSkills,
 			templateTypes: CONFIG.MeasuredTemplate.types,
 		};
 	}


### PR DESCRIPTION
Module not loading in WitcherTRPG system due to incorrect import:
```js
foundry.js:655 Error: An error occurred while rendering eU 35. Cannot read properties of undefined (reading 'meleeSkills')
[Detected 4 packages: tokenmagic(0.6.9), puzzle-locks(2.0.2), lib-wrapper(1.13.2.0), colorsettings(3.0.3)]
    at Hooks.onError (foundry.js:654:24)
    at 🎁Hooks.onError#0 (libWrapper-wrapper.js:188:54)
    at foundry.js:5795:13Caused by: TypeError: Cannot read properties of undefined (reading 'meleeSkills')
[Detected 4 packages: tokenmagic(0.6.9), puzzle-locks(2.0.2), lib-wrapper(1.13.2.0), colorsettings(3.0.3)]
    at Object.getData (TheWitcherTRPG.js:87:32)
    at eU.getData (settings.js:245:46)
    at eU._render (foundry.js:5838:29)
    at eU._render (foundry.js:6572:17)
    at eU.render (foundry.js:5793:10)
    at 🎁call_wrapped [as call_wrapped] (libWrapper-wrapper.js:511:22)
    at 🎁Application.prototype.render#puzzle-locks (index.js:2:30924)
    at 🎁call_wrapper [as call_wrapper] (libWrapper-wrapper.js:639:16)
    at 🎁Application.prototype.render#0 (libWrapper-wrapper.js:193:20)
    at SettingsConfig.onClickSubmenuWrapper (colorSetting.js:21:24)
    at 🎁call_wrapper [as call_wrapper] (libWrapper-wrapper.js:614:14)
    at 🎁SettingsConfig.prototype._onClickSubmenu#0 (libWrapper-wrapper.js:193:20)
    at HTMLButtonElement.dispatch (jquery.min.js:2:40035)
    at v.handle (jquery.min.js:2:38006)
```